### PR TITLE
Use the same style of URL filtering that Django uses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changes
 =======
 
-Unreleased
-----------
+1.3.0
+-----
 
 - Use related_name (if present) when linking to reverse relations
 - Update admin URL filters to be consistent with Django's defaults

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Use related_name (if present) when linking to reverse relations
+- Update admin URL filters to be consistent with Django's defaults
 
 1.2.2 (2021-09-15)
 ------------------

--- a/relatives/__init__.py
+++ b/relatives/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.2.2.post0'
+__version__ = '1.3.0.a1'

--- a/relatives/templatetags/relatives.py
+++ b/relatives/templatetags/relatives.py
@@ -83,8 +83,14 @@ def related_objects(obj):
             plural_name = related.related_name.replace("_", " ")
         else:
             plural_name = to_model._meta.verbose_name_plural
+        if hasattr(related.field, 'attname'):
+            field = related.field.attname
+            if hasattr(related.field, 'm2m_reverse_target_field_name'):
+                field += "__" + related.field.m2m_reverse_target_field_name()
+        else:
+            field = related.field.name
         object_list.append({
             'plural_name': plural_name,
-            'url': smart_text('%s?%s=%s' % (url, related.field.name, obj.pk)),
+            'url': smart_text(f"{url}?{field}__exact={obj.pk}"),
         })
     return object_list

--- a/relatives/tests/tests.py
+++ b/relatives/tests/tests.py
@@ -146,17 +146,18 @@ class RelatedObjectsTagTest(TestCase):
         ship = Ship.objects.create(id=1, name="Star of India")
         body = render_to_string('related_objects_fk_test.html', {'obj': ship})
         self.assertEqual(body.strip(),
-                         '<a href="/adm/tests/sailor/?ship=1">Sailors</a>')
+                         '<a href="/adm/tests/sailor/?ship_id__exact=1">Sailors</a>')
 
     def test_two_foreign_keys(self):
         eater = Eater.objects.create(id=1, name="Cheryl")
         body = render_to_string('related_objects_fk_test.html', {'obj': eater})
         self.assertEqual(
             body.strip(),
-            '<a href="/adm/tests/meal/?prepared=1">Meals prepared</a>'
-            '<a href="/adm/tests/meal/?reviewed=1">Meals reviewed</a>',
+            '<a href="/adm/tests/meal/?prepared_id__exact=1">'
+            'Meals prepared</a>'
+            '<a href="/adm/tests/meal/?reviewed_id__exact=1">'
+            'Meals reviewed</a>',
         )
-
 
     def test_no_admin_url(self):
         thing = Something.objects.create()
@@ -170,8 +171,10 @@ class RelatedObjectsTagTest(TestCase):
         actor.movies.add(movie)
         body = render_to_string('related_objects_m2m_test.html',
                                 {'obj': movie})
-        self.assertEqual(body.strip(),
-                         '<a href="/adm/tests/actor/?movies=1">Actors</a>')
+        self.assertEqual(
+            body.strip(),
+            '<a href="/adm/tests/actor/?movies__id__exact=1">Actors</a>',
+        )
 
     def test_reverse_many_to_many(self):
         movie = Movie.objects.create(id=1, name="Yojimbo")
@@ -191,21 +194,29 @@ class RelatedObjectsTagTest(TestCase):
         book = Book.objects.create(name="Django")
         Image.objects.create(content_object=book)
         ct_pk = ContentType.objects.get_for_model(book).pk
-        exp = '<a href="/adm/tests/image/?ct={0}&amp;obj_id={1}">Images</a>'\
-            .format(ct_pk, book.pk)
-        body = render_to_string('related_objects_generic_test.html',
-                                {'obj': book})
-        self.assertEqual(body.strip(), exp)
+        expected = (
+            '<a href="/adm/tests/image/'
+            f'?ct={ct_pk}&amp;obj_id__exact={book.pk}">Images</a>'
+        )
+        body = render_to_string(
+            'related_objects_generic_test.html',
+            {'obj': book},
+        )
+        self.assertEqual(body.strip(), expected)
 
     def test_generic_relation_and_gfk_present(self):
         journal = Journal.objects.create(name="Django")
         Image.objects.create(content_object=journal)
         ct_pk = ContentType.objects.get_for_model(journal).pk
-        exp = '<a href="/adm/tests/image/?ct={0}&amp;obj_id={1}">Images</a>'\
-            .format(ct_pk, journal.pk)
-        body = render_to_string('related_objects_generic_test.html',
-                                {'obj': journal})
-        self.assertEqual(body.strip(), exp)
+        expected = (
+            '<a href="/adm/tests/image/'
+            f'?ct={ct_pk}&amp;obj_id__exact={journal.pk}">Images</a>'
+        )
+        body = render_to_string(
+            'related_objects_generic_test.html',
+            {'obj': journal},
+        )
+        self.assertEqual(body.strip(), expected)
 
     def test_with_removed_model(self):
         cache.clear()


### PR DESCRIPTION
- `?ship_id__exact=4` instead of `?ship=4`
- `?movies__id__exact=4` instead of `?movies=4`

Fixes #19